### PR TITLE
Avoid messages "Ip address not defined for poller" in centcore.log

### DIFF
--- a/host-monitoring/src/action.php
+++ b/host-monitoring/src/action.php
@@ -192,7 +192,7 @@ try {
             }
             foreach ($hosts as $hostId) {
                 if ($hostId != 0) {
-                  $externalCmd->$externalCommandMethod(sprintf($command, $hostObj->getHostName($hostId)), $hostObj->getHostPollerId($hostId));
+                    $externalCmd->$externalCommandMethod(sprintf($command, $hostObj->getHostName($hostId)), $hostObj->getHostPollerId($hostId));
                 }
             }
             $externalCmd->write();

--- a/host-monitoring/src/action.php
+++ b/host-monitoring/src/action.php
@@ -191,8 +191,9 @@ try {
                 $externalCommandMethod = 'setProcessCommand';
             }
             foreach ($hosts as $hostId) {
-                if ($hostId == 0) continue;
-                $externalCmd->$externalCommandMethod(sprintf($command, $hostObj->getHostName($hostId)), $hostObj->getHostPollerId($hostId));
+                if ($hostId != 0) {
+                  $externalCmd->$externalCommandMethod(sprintf($command, $hostObj->getHostName($hostId)), $hostObj->getHostPollerId($hostId));
+                }
             }
             $externalCmd->write();
         }

--- a/host-monitoring/src/action.php
+++ b/host-monitoring/src/action.php
@@ -191,6 +191,7 @@ try {
                 $externalCommandMethod = 'setProcessCommand';
             }
             foreach ($hosts as $hostId) {
+                if ($hostId == 0) continue;
                 $externalCmd->$externalCommandMethod(sprintf($command, $hostObj->getHostName($hostId)), $hostObj->getHostPollerId($hostId));
             }
             $externalCmd->write();

--- a/host-monitoring/src/sendCmd.php
+++ b/host-monitoring/src/sendCmd.php
@@ -124,21 +124,23 @@ try {
             $externalCommandMethod = 'setProcessCommand';
         }
         foreach ($hosts as $hostId) {
-            if ($hostId == 0) continue;
-            $hostname = $hostObj->getHostName($hostId);
-            $pollerId = $hostObj->getHostPollerId($hostId);
-            $externalCmd->$externalCommandMethod(sprintf($command, $hostname), $pollerId);
-            if (isset($forceCmd)) {
-                $externalCmd->$externalCommandMethod(sprintf($forceCmd, $hostname), $pollerId);
-            }
-            if (isset($_POST['processServices'])) {
-                $services = $svcObj->getServiceId(null, $hostname);
-                foreach($services as $svcDesc => $svcId) {
-                    $externalCmd->$externalCommandMethod(sprintf($commandSvc, $hostname, $svcDesc), $pollerId);
-                    if (isset($forceCmdSvc)) {
-                        $externalCmd->$externalCommandMethod(sprintf($forceCmdSvc, $hostname, $svcDesc), $pollerId);
-                    }
-                }
+            if ($hostId != 0) {
+              $hostname = $hostObj->getHostName($hostId);
+              $pollerId = $hostObj->getHostPollerId($hostId);
+              $externalCmd->$externalCommandMethod(sprintf($command, $hostname), $pollerId);
+            
+              if (isset($forceCmd)) {
+                  $externalCmd->$externalCommandMethod(sprintf($forceCmd, $hostname), $pollerId);
+              }
+              if (isset($_POST['processServices'])) {
+                  $services = $svcObj->getServiceId(null, $hostname);
+                  foreach($services as $svcDesc => $svcId) {
+                      $externalCmd->$externalCommandMethod(sprintf($commandSvc, $hostname, $svcDesc), $pollerId);
+                      if (isset($forceCmdSvc)) {
+                          $externalCmd->$externalCommandMethod(sprintf($forceCmdSvc, $hostname, $svcDesc), $pollerId);
+                      }
+                  }
+              }
             }
         }
         $externalCmd->write();

--- a/host-monitoring/src/sendCmd.php
+++ b/host-monitoring/src/sendCmd.php
@@ -124,6 +124,7 @@ try {
             $externalCommandMethod = 'setProcessCommand';
         }
         foreach ($hosts as $hostId) {
+            if ($hostId == 0) continue;
             $hostname = $hostObj->getHostName($hostId);
             $pollerId = $hostObj->getHostPollerId($hostId);
             $externalCmd->$externalCommandMethod(sprintf($command, $hostname), $pollerId);

--- a/host-monitoring/src/sendCmd.php
+++ b/host-monitoring/src/sendCmd.php
@@ -125,22 +125,22 @@ try {
         }
         foreach ($hosts as $hostId) {
             if ($hostId != 0) {
-              $hostname = $hostObj->getHostName($hostId);
-              $pollerId = $hostObj->getHostPollerId($hostId);
-              $externalCmd->$externalCommandMethod(sprintf($command, $hostname), $pollerId);
-            
-              if (isset($forceCmd)) {
-                  $externalCmd->$externalCommandMethod(sprintf($forceCmd, $hostname), $pollerId);
-              }
-              if (isset($_POST['processServices'])) {
-                  $services = $svcObj->getServiceId(null, $hostname);
-                  foreach($services as $svcDesc => $svcId) {
-                      $externalCmd->$externalCommandMethod(sprintf($commandSvc, $hostname, $svcDesc), $pollerId);
-                      if (isset($forceCmdSvc)) {
-                          $externalCmd->$externalCommandMethod(sprintf($forceCmdSvc, $hostname, $svcDesc), $pollerId);
-                      }
-                  }
-              }
+                $hostname = $hostObj->getHostName($hostId);
+                $pollerId = $hostObj->getHostPollerId($hostId);
+                $externalCmd->$externalCommandMethod(sprintf($command, $hostname), $pollerId);
+              
+                if (isset($forceCmd)) {
+                    $externalCmd->$externalCommandMethod(sprintf($forceCmd, $hostname), $pollerId);
+                }
+                if (isset($_POST['processServices'])) {
+                    $services = $svcObj->getServiceId(null, $hostname);
+                    foreach($services as $svcDesc => $svcId) {
+                        $externalCmd->$externalCommandMethod(sprintf($commandSvc, $hostname, $svcDesc), $pollerId);
+                        if (isset($forceCmdSvc)) {
+                            $externalCmd->$externalCommandMethod(sprintf($forceCmdSvc, $hostname, $svcDesc), $pollerId);
+                        }
+                    }
+                }
             }
         }
         $externalCmd->write();


### PR DESCRIPTION
Hello,

**Step to reproduce:**
* Select all lines with the all selection button
* Execute an action on this selection
* Message "Ip address not defined for poller" is displayed in centcore.log

**Reason:**
The first selection which include the column name is considered as a monitoring line. The widget will try to send action on this line.

Thanks.