### PR TITLE
fix(downtime popup): Fix popup does not close

### DIFF
--- a/host-monitoring/src/action.php
+++ b/host-monitoring/src/action.php
@@ -228,7 +228,7 @@ jQuery(function() {
 
 function closeBox()
 {
-	parent.jQuery('#WidgetDowntime').centreonPopin('close');
+	jQuery('#WidgetDowntime').centreonPopin('close');
 }
 
 function sendCmd()


### PR DESCRIPTION
The downtime popup does not close when we click on the 'Set Downtime' button.