### PR TITLE
enh(UI): Option to hide chart link/icon

### DIFF
--- a/host-monitoring/configs.xml
+++ b/host-monitoring/configs.xml
@@ -39,6 +39,7 @@
         <preference label="Display Severities" name="display_severities" defaultValue="0" type="boolean" header="Columns"/>
         <preference label="Display Host Name" name="display_host_name" defaultValue="1" type="boolean"/>
         <preference label="Display Host Alias" name="display_host_alias" defaultValue="0" type="boolean"/>
+        <preference label="Display Chart Link/Icon" name="display_chart_icon" defaultValue="1" type="boolean"/>
         <preference label="Display Status" name="display_status" defaultValue="1" type="boolean"/>
         <preference label="Display IP" name="display_ip" defaultValue="0" type="boolean"/>
         <preference label="Display Last Check" name="display_last_check" defaultValue="0" type="boolean"/>

--- a/host-monitoring/src/table.ihtml
+++ b/host-monitoring/src/table.ihtml
@@ -71,9 +71,11 @@
                         <img src='/{$centreon_web_path}/img/icons/link.png' class='ico-14'>
                     </a>
                     {/if}
+                    {if $preferences.display_chart_icon}
                     <a target=_blank href='/{$centreon_web_path}/main.php?p=204&amp;mode=0&svc_id={$elem.encoded_host_name}'>
                         <img src='/{$centreon_web_path}/img/icons/chart.png' class='ico-18' title='{$title_graph}' />
                     </a>
+                    {/if}
                 </div>
         </td>
         {/if}


### PR DESCRIPTION
Hi,

As in https://github.com/centreon/centreon-widget-service-monitoring/pull/130, this PR adds a tunable to toggle chart link/icon in the widget.
Depending on the use case, the chart icon is "useless", removing it then saves space / makes nicer output.

Thank you 👍