### PR TITLE
fix(web): correctly compute localized downtime's datepickers

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,96 @@
+# Security Policy
+
+Centreon takes the security of our software products seriously.
+
+If you believe you have found a security vulnerability, please report it to us as described below.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Send an email to security@centreon.com. If possible, encrypt your message with our PGP key below.
+
+You should receive a response within 48 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
+
+To help us better understand the nature and scope of the possible issue, please describe as much as you can: 
+
+* Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+* Full paths of source file(s) related to the manifestation of the issue
+* The location of the affected source code (tag/branch/commit or direct URL)
+* Any special configuration required to reproduce the issue
+* Step-by-step instructions to reproduce the issue
+* Proof-of-concept or exploit code (if possible)
+* Impact of the issue, including how an attacker might exploit the issue
+
+## PGP information
+
+### Public key
+
+```
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBF5Cei0BEADhmq8U5rvapCD4AtG0dMpdILACNXfDeU9egywe6eP23fia+RDZ
+umlCGqPeBny3zU+wcE4Kik6nsCmqy61rgHsgTVbWEEeu1AJoJfq0GneBBwWI5sWV
+QwAUTmJSEJgYB9oRyHErhhxuBdjfbLqHRV2fMZjyQOqTRQtZ1PuJHbbzB29Plj1q
+K0VYfO5q2RLWDol5TbtiBEDiF1Wl3UcPF2jmlgHWS/iCpmFKz2ABOkKgUBpn83Sa
+E+PYY/CMOL8YAd77oV47a0yA9kuLgEcQITviB7lU2Yq9URVSWG1I3SxFFU6/IEn6
+HFj3vbs8zWEn/LN1mCW5MlDPH2VlHp8QTdUGrrKSM0mEv/xddkZx6QFZ7K0bVzNB
+1fGRTcn8hxbw0YVsJyUAMpZORhnKJS5VLSyZAU7y+EGVy9Q7VurjZN51HBgtuArl
+ZorLscu8FS6XLFXzGiePKUyJ2RN+c8o78FsB+QZ6Zgxwx/F06zRYXpgZM1ONMTnu
+MTeg1ea5w7m8DQCQAElk5EQBTqtk+XCRoKz4Bb4BuqFrqbx1MoFHY6QXi+5ThNXI
+4xIja2r6KpfKSFE6ewLU0ew521eBbA4i/ib+DMPRQ1xORiuTTJWgxqMX1jL7tnYi
+A78LF+3PfHwiMRM6c+csLE/aw9aVGlpyULj/9LVpyqdQeEYoBes0SiDcGwARAQAB
+tClDZW50cmVvbiBTZWN1cml0eSA8c2VjdXJpdHlAY2VudHJlb24uY29tPokCVAQT
+AQgAPhYhBMN36dUtXBN9PdVztb6vbr9jEQb5BQJeQnotAhsDBQkB4TOABQsJCAcC
+BhUKCQgLAgQWAgMBAh4BAheAAAoJEL6vbr9jEQb5frIP/1361JCYjrTG9zF5REar
+qXQ5pUtqlYgG3fXUm8HJoNrBPnxpVHNlul8B7TtmkIbjPWa444Ez5G/cS/oyYQD8
+9mG92FP+GpQYHDANB3g2BGQwHaORxiBGkrGAtTozptlxqvIxoHty62aSQQ8GW4dA
+M0ce30scRarDbfliyVI1VmFytpIovNsax+dIAbHk21eKy7Ds85qToYoz50AVgNoJ
+IQmZdVhittrahqFLhlGLPNkngj7efk/2XOCOsGCa7pv2J9iJQ3gZkF5JPnQnLRv2
+szMPThAVa/xZSCjoxqh4dzcewZVuj/Hxw+tdoJK00AqgHen+C23jEiDOK3cTrxVI
+wKTs/Og1LjLSLN0HUYjazE9jGvm9Mo+yQuKoJEyx6pOWh9APSInGoy2TJa/caQ73
+sSlMpl84a6LiyP+yUAJYFjrjwUzbrCR4Y4GRDHay2YnHcGCdO5EXvN+retEl1cNb
+X7PKkEDby4CEsuAFUB/liAAbQILVjTJ9tKKtHER9VJwkLoR04N18N35tdbsHdDmW
+C+BjwwHCSXbWeWNaE2zmkzb46kMpjgtdPwdO5TsI+lpK5lcrrldygoV7srB4Sera
+5k4Ci65K9vNQ6KTqds/riyiZj9ofFuHd81NYCoUvGx2DyJrtEnW0ay+3m3lzsdTZ
+eBEtw/3Gx7DSjgn4X9soJHsRuQINBF5CgfMBEADmxcDYgg+sI1f9SkdRZY/cVzWQ
+0kmSRMQ5Q1wABc07uXeFQlpubZEWzeB13v0puI4A0WGjSNnWD0JBJZSxqFiKlytZ
+q+xJnO1eLjN3A4RlvIxFnjmtZXW2x3bGS/t9TbWIDvgFs4RfiyOsVimFRdvB3YEE
+UtrcLnb5cmxLznDQwpJTStevuWuoVhc8bfiGepiAzXhdOlJ85keH8Hq3Ujgqs/dx
+mBa68hokTTMt33SwQ9KAoTQvrKNu1B+fTSQBmN3yBzKiZEX3JzapK70TfR9mc1CJ
+JiLoJyKqDhyY0IaMCqd5mdA5Q2TdXtn/iwFrxiyUi+1QF5I4c19hUoZchn5I+exw
+anLabHP6EsM2kHeO8J1nHiNJ2b58lxVcUBTMkkoQLxN1shOozkYiapX33Cxv+Smy
+57Pw8SpbZfZqDfmazUgF/aboJY9vcQ1+fK6VzmXK42GAYu968Z9Vvxi6+qNPIz1P
+cCC6t+Yzlrv3EadFUTAeXiHjpxjef3Lv7BWLZDr5psaCgvRzO0Ffn4hniUiKqTTb
+wHJxDA1iP9vfEAh61kpBQ8p+C6h4+hn5OWCbz6GBp+wEG1Rswrz734K7Aiywr8pH
+la1+oXYkRrAZop9Oagh9weimbR0ZZ76kD4duSq3blV6mhh7Cs94e4HINB6NzMfXg
+YYk4Dwr6aiW2Np5MLQARAQABiQI8BBgBCAAmFiEEw3fp1S1cE3091XO1vq9uv2MR
+BvkFAl5CgfMCGwwFCQHhM4AACgkQvq9uv2MRBvnkkw//UbXbzC0tcStxnSqRXmdL
+Lv11lFa2hFcAP3/aLoHyryF4qoiqhGc0K6nrd9ApE2tMia1PKV3jiBlhTlXWeR8m
+Y7/y3OJSqjSg8qu9L14AQhLzvYNEAc3TVhAAMNQoekDg/QapQSPxpqlPjhFyF91K
+jjvSXPHVuFWKmYvPqldceTX8J032fOGDrhAPmzaXo487CDPVuQe3Xg8V+yZdLcpw
+KBU800tQ/GkI5Zb2HrxIQ/qEPmcFHcpQQnbu7nuBe8OzfwWCIZ3clN55LYF9FgmQ
+MoefpoBeEpWxNAY23KT6MkjeX/VxtRF+gwGTPGAoRoiRrrywLSPAlzj0V4iglSs7
+wPqugycY7sfOGZ2KzciLmUkM8pd2/Kv1AFF3zYznvSmov71el8hh46FCE4a2xo71
+kmh+//+obMyASf6npTIeNwBKV0sSZ49AoEd/kA6agYXbEjRIPLgVyvCyEHGhmAOS
+U1UYTpy6qXTX2Xj0rCvOXlxDCWIMyesjjBxKyuoe4TYMPp+D9ZEBndN45lYNmfBG
+Vl95htR6juC4rRBtQZDgZFzD9y20shRsXFZ9t9GSpO5wmKOxuFwPq6c9pyiUM83T
+Y6odD3X30YsLpvwBEXlvs0pLXVjlJn3PZsKE5qEbOIy29elhjoMDuZ9F3kWD4ykv
+oWAyTvK/VwbB77CTz1yTUSE=
+=3kAj
+-----END PGP PUBLIC KEY BLOCK-----
+```
+
+| Tag | Value |
+| -- | -- |
+| ID | BEAF6EBF631106F9 |
+| Type | RSA |
+| Size | 4096 |
+| Created | 2020-02-11 |
+| Expires | 2021-02-10 |
+| Cipher |AES-256|
+| Fingerprint | C377 E9D5 2D5C 137D 3DD5 73B5 BEA F6EBF 6311 06F9 |
+
+## Bug bounty
+
+We don't have a bug bounty program but this is something we are thinking about.

--- a/host-monitoring/src/action.php
+++ b/host-monitoring/src/action.php
@@ -76,15 +76,9 @@ try {
 
     $defaultDuration = 7200;
     $defaultScale = 's';
-    if (
-        isset($centreon->optGen['monitoring_dwt_duration'])
-        && $centreon->optGen['monitoring_dwt_duration']
-    ) {
+    if (!empty($centreon->optGen['monitoring_dwt_duration'])) {
         $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
-        if (
-            isset($centreon->optGen['monitoring_dwt_duration_scale'])
-            && $centreon->optGen['monitoring_dwt_duration_scale']
-        ) {
+        if (!empty($centreon->optGen['monitoring_dwt_duration_scale'])) {
             $defaultScale = $centreon->optGen['monitoring_dwt_duration_scale'];
         }
     }
@@ -113,37 +107,31 @@ try {
 
             /* default ack options */
             $persistent_checked = '';
-            if (
-                isset($centreon->optGen['monitoring_ack_persistent'])
-                && $centreon->optGen['monitoring_ack_persistent']
-            ) {
+            if (!empty($centreon->optGen['monitoring_ack_persistent'])) {
                 $persistent_checked = 'checked';
             }
             $template->assign('persistent_checked', $persistent_checked);
 
             $sticky_checked = '';
-            if (isset($centreon->optGen['monitoring_ack_sticky']) && $centreon->optGen['monitoring_ack_sticky']) {
+            if (!empty($centreon->optGen['monitoring_ack_sticky'])) {
                 $sticky_checked = 'checked';
             }
             $template->assign('sticky_checked', $sticky_checked);
 
             $notify_checked = '';
-            if (isset($centreon->optGen['monitoring_ack_notify']) && $centreon->optGen['monitoring_ack_notify']) {
+            if (!empty($centreon->optGen['monitoring_ack_notify'])) {
                 $notify_checked = 'checked';
             }
             $template->assign('notify_checked', $notify_checked);
 
             $process_service_checked = '';
-            if (isset($centreon->optGen['monitoring_ack_svc']) && $centreon->optGen['monitoring_ack_svc']) {
+            if (!empty($centreon->optGen['monitoring_ack_svc'])) {
                 $process_service_checked = 'checked';
             }
             $template->assign('process_service_checked', $process_service_checked);
 
             $force_active_checked = '';
-            if (
-                isset($centreon->optGen['monitoring_ack_active_checks'])
-                && $centreon->optGen['monitoring_ack_active_checks']
-            ) {
+            if (!empty($centreon->optGen['monitoring_ack_active_checks'])) {
                 $force_active_checked = 'checked';
             }
             $template->assign('force_active_checked', $force_active_checked);
@@ -155,21 +143,24 @@ try {
             $template->assign('titleLabel', _("Host Downtime"));
             $template->assign('submitLabel', _("Set Downtime"));
             $template->assign('defaultDuration', $defaultDuration);
+            $template->assign('sDurationLabel', _("seconds"));
+            $template->assign('mDurationLabel', _("minutes"));
+            $template->assign('hDurationLabel', _("hours"));
+            $template->assign('dDurationLabel', _("days"));
             $template->assign($defaultScale . 'DefaultScale', 'selected');
 
             /* default downtime options */
             $fixed_checked = '';
-            if (isset($centreon->optGen['monitoring_dwt_fixed']) && $centreon->optGen['monitoring_dwt_fixed']) {
+            if (!empty($centreon->optGen['monitoring_dwt_fixed'])) {
                 $fixed_checked = 'checked';
             }
             $template->assign('fixed_checked', $fixed_checked);
 
             $process_service_checked = '';
-            if (isset($centreon->optGen['monitoring_dwt_svc']) && $centreon->optGen['monitoring_dwt_svc']) {
+            if (!empty($centreon->optGen['monitoring_dwt_svc'])) {
                 $process_service_checked = 'checked';
             }
             $template->assign('process_service_checked', $process_service_checked);
-
             $template->display('downtime.ihtml');
         }
     } else {

--- a/host-monitoring/src/action.php
+++ b/host-monitoring/src/action.php
@@ -239,7 +239,9 @@ jQuery(function() {
 
 	//initializing datepicker and timepicker
 	jQuery(".timepicker").each(function () {
-		$(this).val(moment().tz(localStorage.getItem('realTimezone') ? localStorage.getItem('realTimezone') : moment.tz.guess()).format("HH:mm"));
+		if (! $(this).val()) {
+			$(this).val(moment().tz(localStorage.getItem('realTimezone') ? localStorage.getItem('realTimezone') : moment.tz.guess()).format("HH:mm"));
+		}
 	});
 	jQuery("#start_time, #end_time").timepicker();
 	initDatepicker();

--- a/host-monitoring/src/action.php
+++ b/host-monitoring/src/action.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005-2020 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
@@ -46,9 +47,10 @@ require_once $centreon_path . 'www/class/centreonExternalCommand.class.php';
 session_start();
 
 try {
-    if (!isset($_SESSION['centreon']) ||
-        !isset($_REQUEST['cmd']) ||
-        !isset($_REQUEST['selection'])
+    if (
+        !isset($_SESSION['centreon'])
+        || !isset($_REQUEST['cmd'])
+        || !isset($_REQUEST['selection'])
     ) {
         throw new Exception('Missing data');
     }
@@ -62,7 +64,7 @@ try {
 
     $selection = '';
     $hosts = explode(",", $_GET['selection']);
-    foreach($hosts as $host) {
+    foreach ($hosts as $host) {
         $selection .= (filter_var($host, FILTER_VALIDATE_INT) ?: 0) . ',';
     }
     $selection = rtrim($selection, ',');
@@ -74,12 +76,14 @@ try {
 
     $defaultDuration = 7200;
     $defaultScale = 's';
-    if (isset($centreon->optGen['monitoring_dwt_duration']) &&
-        $centreon->optGen['monitoring_dwt_duration']
+    if (
+        isset($centreon->optGen['monitoring_dwt_duration'])
+        && $centreon->optGen['monitoring_dwt_duration']
     ) {
         $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
-        if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&
-            $centreon->optGen['monitoring_dwt_duration_scale']
+        if (
+            isset($centreon->optGen['monitoring_dwt_duration_scale'])
+            && $centreon->optGen['monitoring_dwt_duration_scale']
         ) {
             $defaultScale = $centreon->optGen['monitoring_dwt_duration_scale'];
         }
@@ -109,8 +113,9 @@ try {
 
             /* default ack options */
             $persistent_checked = '';
-            if (isset($centreon->optGen['monitoring_ack_persistent']) &&
-                $centreon->optGen['monitoring_ack_persistent']
+            if (
+                isset($centreon->optGen['monitoring_ack_persistent'])
+                && $centreon->optGen['monitoring_ack_persistent']
             ) {
                 $persistent_checked = 'checked';
             }
@@ -135,8 +140,9 @@ try {
             $template->assign('process_service_checked', $process_service_checked);
 
             $force_active_checked = '';
-            if (isset($centreon->optGen['monitoring_ack_active_checks']) &&
-                $centreon->optGen['monitoring_ack_active_checks']
+            if (
+                isset($centreon->optGen['monitoring_ack_active_checks'])
+                && $centreon->optGen['monitoring_ack_active_checks']
             ) {
                 $force_active_checked = 'checked';
             }
@@ -144,7 +150,6 @@ try {
 
             $template->display('acknowledge.ihtml');
         } elseif ($cmd == 75) {
-
             $template->assign('downtimeHostSvcLabel', _("Set downtime on services of hosts"));
             $template->assign('defaultMessage', sprintf(_('Downtime set by %s'), $centreon->user->alias));
             $template->assign('titleLabel', _("Host Downtime"));
@@ -168,31 +173,31 @@ try {
             $template->display('downtime.ihtml');
         }
     } else {
-        $command = "";
+        $command = '';
         switch ($cmd) {
-                /* remove ack */
-                case 73 :
-                    $command = "REMOVE_HOST_ACKNOWLEDGEMENT;%s";
-                    break;
-                /* enable notif */
-                case 82 :
-                    $command = "ENABLE_HOST_NOTIFICATIONS;%s";
-                    break;
-                /* disable notif */
-                case 83 :
-                    $command = "DISABLE_HOST_NOTIFICATIONS;%s";
-                    break;
-                /* enable check */
-                case 92 :
-                    $command = "ENABLE_HOST_CHECK;%s";
-                    break;
-                /* disable check */
-                case 93 :
-                    $command = "DISABLE_HOST_CHECK;%s";
-                    break;
-                default :
-                    throw new Exception('Unknown command');
-                    break;
+            /* remove ack */
+            case 73:
+                $command = "REMOVE_HOST_ACKNOWLEDGEMENT;%s";
+                break;
+            /* enable notif */
+            case 82:
+                $command = "ENABLE_HOST_NOTIFICATIONS;%s";
+                break;
+            /* disable notif */
+            case 83:
+                $command = "DISABLE_HOST_NOTIFICATIONS;%s";
+                break;
+            /* enable check */
+            case 92:
+                $command = "ENABLE_HOST_CHECK;%s";
+                break;
+            /* disable check */
+            case 93:
+                $command = "DISABLE_HOST_CHECK;%s";
+                break;
+            default:
+                throw new Exception('Unknown command');
+                break;
         }
         if ($command != "") {
             $externalCommandMethod = 'set_process_command';
@@ -202,8 +207,8 @@ try {
             foreach ($hosts as $hostId) {
                 $hostId = filter_var($hostId, FILTER_VALIDATE_INT) ?: 0;
                 if ($hostId !== 0) {
-                    $externalCmd->$externalCommandMethod(sprintf(
-                        $command, $hostObj->getHostName($hostId)),
+                    $externalCmd->$externalCommandMethod(
+                        sprintf($command, $hostObj->getHostName($hostId)),
                         $hostObj->getHostPollerId($hostId)
                     );
                 }
@@ -219,70 +224,72 @@ try {
 <div id='result'></div>
 
 <script type='text/javascript'>
-var result = <?php echo $result;?>;
-var successMsg = "<?php echo $successMsg;?>";
+    var result = <?php echo $result;?>;
+    var successMsg = "<?php echo $successMsg;?>";
 
-jQuery(function() {
-	if (result) {
-		jQuery("#result").html(successMsg);
-		setTimeout('closeBox()', 2000);
-	}
-	jQuery("#submit").click(function() {
-			sendCmd();
-	});
-	//$("#ListTable").styleTable();
-	jQuery("#submit").button();
-	toggleDurationField();
-	jQuery("[name=fixed]").click(function() {
-		toggleDurationField();
-	});
+    jQuery(function() {
+        if (result) {
+            jQuery("#result").html(successMsg);
+            setTimeout('closeBox()', 2000);
+        }
+        jQuery("#submit").click(function() {
+            sendCmd();
+        });
+        jQuery("#submit").button();
+        toggleDurationField();
+        jQuery("[name=fixed]").click(function() {
+            toggleDurationField();
+        });
 
-	//initializing datepicker and timepicker
-	jQuery(".timepicker").each(function () {
-		if (! $(this).val()) {
-			$(this).val(moment().tz(localStorage.getItem('realTimezone') ? localStorage.getItem('realTimezone') : moment.tz.guess()).format("HH:mm"));
-		}
-	});
-	jQuery("#start_time, #end_time").timepicker();
-	initDatepicker();
-	turnOnEvents();
-	updateEndTime();
-});
+        //initializing datepicker and timepicker
+        jQuery(".timepicker").each(function () {
+            if (!$(this).val()) {
+                $(this).val(moment().tz(localStorage.getItem('realTimezone')
+                    ? localStorage.getItem('realTimezone')
+                    : moment.tz.guess()).format("HH:mm")
+                );
+            }
+        });
+        jQuery("#start_time, #end_time").timepicker();
+        initDatepicker();
+        turnOnEvents();
+        updateEndTime();
+    });
 
-function closeBox()
-{
-	jQuery('#WidgetDowntime').centreonPopin('close');
-}
+    function closeBox()
+    {
+        jQuery('#WidgetDowntime').centreonPopin('close');
+    }
 
-function sendCmd()
-{
-	fieldResult = true;
-	if (jQuery("#comment") && !jQuery("#comment").val()) {
-		fieldResult = false;
-	}
-	if (fieldResult == false) {
-		jQuery("#result").html("<font color=red><b>Please fill all mandatory fields.</b></font>");
-		return false;
-	}
-	jQuery.ajax({
-				type	:	"POST",
-				url	: "./widgets/host-monitoring/src/sendCmd.php",
-				data	: 	jQuery("#Form").serialize(),
-				success	:	function() {
-								jQuery("#result").html(successMsg);
-								setTimeout('closeBox()', 2000);
-							}
-		   });
-}
+    function sendCmd()
+    {
+        fieldResult = true;
+        if (jQuery("#comment") && !jQuery("#comment").val()) {
+            fieldResult = false;
+        }
+        if (fieldResult == false) {
+            jQuery("#result").html("<font color=red><b>Please fill all mandatory fields.</b></font>");
+            return false;
+        }
+        jQuery.ajax({
+            type : "POST",
+            url : "./widgets/host-monitoring/src/sendCmd.php",
+            data : jQuery("#Form").serialize(),
+            success : function() {
+                jQuery("#result").html(successMsg);
+                setTimeout('closeBox()', 2000);
+            }
+       });
+    }
 
-function toggleDurationField()
-{
-	if (jQuery("[name=fixed]").is(':checked')) {
-		jQuery("[name=duration]").attr('disabled', true);
-		jQuery("[name=duration_scale]").attr('disabled', true);
-	} else {
-		jQuery("[name=duration]").removeAttr('disabled');
-		jQuery("[name=duration_scale]").removeAttr('disabled');
-	}
-}
+    function toggleDurationField()
+    {
+        if (jQuery("[name=fixed]").is(':checked')) {
+            jQuery("[name=duration]").attr('disabled', true);
+            jQuery("[name=duration_scale]").attr('disabled', true);
+        } else {
+            jQuery("[name=duration]").removeAttr('disabled');
+            jQuery("[name=duration_scale]").removeAttr('disabled');
+        }
+    }
 </script>

--- a/host-monitoring/src/downtime.ihtml
+++ b/host-monitoring/src/downtime.ihtml
@@ -1,6 +1,4 @@
 <form name="Form" id="Form">
-    <input type="hidden" id="duration_scale" value="s" />
-    <input type="hidden" id="duration" value="{$duration}" />
 	<table class="table">
 		<tr>
 			<td style="color: #00bfb3;" class ="FormHeader" colspan="2">
@@ -12,7 +10,7 @@
 			<td class="FormRowField">{$startLabel}<span style='color: red;'> *</span></td>
 			<td class="FormRowValue">
 				<input type='text' class="datepicker" id='downtimestart' name='start' value='' size='9' />
-				<input id="start_time" size="5" class="timepicker" name="start_time" type="text" value='{$defaultHourStart}:{$defaultMinuteStart}'>
+				<input id="start_time" size="5" class="timepicker" name="start_time" type="text" value=''>
 				<input type='hidden' class='alternativeDate' id='altDateStart' size='10' name="alternativeDateStart" />
 			</td>
 		</tr>
@@ -21,7 +19,7 @@
 			<td class="FormRowField">{$endLabel}<span style='color: red;'> *</span></td>
 			<td class="FormRowValue">
 				<input class="datepicker" type='text' id='downtimeend' name='end' value='' size='9' />
-				<input id="end_time" size="5" class="timepicker" name="end_time" type="text" value='{$defaultHourEnd}:{$defaultMinuteEnd}'>
+				<input id="end_time" size="5" class="timepicker" name="end_time" type="text" value=''>
 				<input type='hidden' class='alternativeDate' id='altDateEnd' size='10' name="alternativeDateEnd" />
 			</td>
 		</tr>
@@ -29,10 +27,13 @@
 		<tr>
 			<td class="FormRowField">{$durationLabel}</td>
 			<td class="FormRowValue">
-				<input type='text' name='dayduration' size='2' value='{$defaultDayDuration}' />&nbsp;{$daysLabel}
-				<input type='text' name='hourduration' size='2' value='{$defaultHourDuration}' />&nbsp;{$hoursLabel}
-				<input type='text' name='minuteduration' size='2' value='{$defaultMinuteDuration}' />&nbsp;{$minutesLabel}
-                <input type='text' name='secondduration' size='5' value='{$defaultSecondDuration}' />&nbsp;{$secondsLabel}
+				<input type='text' id='duration' name='duration' width='30' value='{$defaultDuration}' />
+				<select id="duration_scale" name="duration_scale">
+					<option value="s" {$sDefaultScale}>Seconds</option>
+					<option value="m" {$mDefaultScale}>Minutes</option>
+					<option value="h" {$hDefaultScale}>Hours</option>
+					<option value="d" {$dDefaultScale}>Days</option>
+				</select>
 			</td>
 		</tr>
 

--- a/host-monitoring/src/downtime.ihtml
+++ b/host-monitoring/src/downtime.ihtml
@@ -5,7 +5,6 @@
 				<h3>{$titleLabel}</h3>
 			</td>
 		</tr>
-
 		<tr>
 			<td class="FormRowField">{$startLabel}<span style='color: red;'> *</span></td>
 			<td class="FormRowValue">
@@ -14,7 +13,6 @@
 				<input type='hidden' class='alternativeDate' id='altDateStart' size='10' name="alternativeDateStart" />
 			</td>
 		</tr>
-
 		<tr>
 			<td class="FormRowField">{$endLabel}<span style='color: red;'> *</span></td>
 			<td class="FormRowValue">
@@ -23,27 +21,24 @@
 				<input type='hidden' class='alternativeDate' id='altDateEnd' size='10' name="alternativeDateEnd" />
 			</td>
 		</tr>
-
 		<tr>
 			<td class="FormRowField">{$durationLabel}</td>
 			<td class="FormRowValue">
 				<input type='text' id='duration' name='duration' width='30' value='{$defaultDuration}' />
 				<select id="duration_scale" name="duration_scale">
-					<option value="s" {$sDefaultScale}>Seconds</option>
-					<option value="m" {$mDefaultScale}>Minutes</option>
-					<option value="h" {$hDefaultScale}>Hours</option>
-					<option value="d" {$dDefaultScale}>Days</option>
+					<option value="s" {$sDefaultScale}>{$sDurationLabel}</option>
+					<option value="m" {$mDefaultScale}>{$mDurationLabel}</option>
+					<option value="h" {$hDefaultScale}>{$hDurationLabel}</option>
+					<option value="d" {$dDefaultScale}>{$dDurationLabel}</option>
 				</select>
 			</td>
 		</tr>
-
 		<tr>
 			<td class="FormRowField">{$fixedLabel}</td>
 			<td class="FormRowValue">
 				<input type='checkbox' name='fixed' {$fixed_checked} />
 			</td>
 		</tr>
-
 		<tr>
 			<td class="FormRowField">{$authorLabel}</td>
 			<td class="FormRowValue">
@@ -51,23 +46,19 @@
 				<input name='author' type='hidden' value='{$author}'/>
 			</td>
 		</tr>
-
 		<tr>
 			<td class="FormRowField">{$commentLabel}<span style='color: red;'> *</span></td>
 			<td class="FormRowValue">
 				<textarea id='comment' name='comment' cols='30' rows='5'>{$defaultMessage}</textarea>
 			</td>
 		</tr>
-
 		<tr>
 			<td class="FormRowField">{$downtimeHostSvcLabel}</td>
 			<td class="FormRowField">
 				<input type='checkbox' name='processServices' {$process_service_checked}/>
 			</td>
 		</tr>
-
 	</table>
-
 	<div id="validForm">
 		<input class="btc bt_info" type='hidden' name='hosts' value='{$hosts}' />
 		<input class="btc bt_info" type='hidden' name='cmdType' value='downtime' />


### PR DESCRIPTION
## Description

Fix an issue where datetime of downtimes weren't correctly computed, when not using the english localization :
- the ending datepicker was not set properly and displayed unconsistent date
- adding a downtime on two days, did not actualize the starting date of the datepicker
- setting an end time before the start date was possible and resulted on useless downtime (not processed by centengine)

**Fixes** MON-3935 & https://github.com/centreon/centreon/pull/7606 from @UrBnW  + https://github.com/centreon/centreon/issues/5963 + https://github.com/centreon/centreon/issues/7337 + https://github.com/centreon/centreon/issues/8266 + #8362 + #8383.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Choose for example the french language.
- Select a default duration on the Administration > parameters > monitoring + duration
- Set a downtime from the monitoring > status > downtime + add downtime
    check that the start and end date and time are set properly.
    check that consistent values are displayed when changing the datepicker and timepicker values.
    check that the datepicker and timepicker are still consistent with the choosen language.

- Do the same from all the other available downtime form in the UI eg :
    status > monitoring > services + choose a resource + set a downtime from the toolbar
    status > monitoring > host + choose a resource + set a downtime from the toolbar
    ...

- Check that no errors are displayed in the logs