### PR TITLE
fix Order By filter invert ASC and DESC

### DIFF
--- a/host-monitoring/src/index.php
+++ b/host-monitoring/src/index.php
@@ -240,6 +240,20 @@ if (isset($preferences['order_by']) && trim($preferences['order_by']) != '') {
     $orderBy = $preferences['order_by'];
 }
 
+if (isset($preferences['order_by']) && trim($preferences['order_by']) != '') {
+    $aOrder = explode(' ', $preferences['order_by']);
+    if (in_array('last_state_change', $aOrder) || in_array('last_hard_state_change', $aOrder)) {
+        if ($aOrder[1] == 'DESC') {
+            $order = 'ASC';
+        } else {
+            $order = 'DESC';
+        }
+        $orderBy = $aOrder[0] . ' ' . $order;
+    } else {
+        $orderBy = $preferences['order_by'];
+    }
+}
+
 $query .= " ORDER BY {$orderBy}";
 $num = filter_var($preferences['entries'], FILTER_VALIDATE_INT) ?: 10;
 $query .= ' LIMIT ' . ($page * $num) . ',' . $num;


### PR DESCRIPTION
Currently if you select order by Duration and select ASC, it displays by DESC and if you select DESC it displays ASC.

I copied the order by part from service monitoring widget  : 
https://github.com/centreon/centreon-widget-service-monitoring/blob/master/service-monitoring/src/index.php

which is working as intended.