### PR TITLE
fix(DT): replace method name with new one

### DIFF
--- a/host-monitoring/src/action.php
+++ b/host-monitoring/src/action.php
@@ -244,7 +244,7 @@ try {
         jQuery("#start_time, #end_time").timepicker();
         initDatepicker();
         turnOnEvents();
-        updateEndTime();
+        updateDateAndTime();
     });
 
     function closeBox()


### PR DESCRIPTION
## Description

Related to this PR : https://github.com/centreon/centreon/pull/8704

- Fix the downtime set between 10pm and noon.
- Remove the modification on the datepicker start value when setting an end value before it.
- Add a popup to display warning for the customer to understand why and how the downtime end time has been changed.
![image](https://user-images.githubusercontent.com/34628915/81579519-91eb5b00-93ac-11ea-86dd-3307eb709ef9.png)


**Fixes** # (MON-3935)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
