### PR TITLE
fix(UI) untick checkboxes when an action is performed MON-5882

### DIFF
--- a/host-monitoring/src/toolbar.php
+++ b/host-monitoring/src/toolbar.php
@@ -104,17 +104,21 @@ jQuery( function() {
                     return tmp[1];
     		    })
                 .get().join(",");
-
             if (checkValues != '') {
                 var url = "./widgets/host-monitoring/src/action.php?widgetId=" + widgetId +
                     "&selection=" + checkValues + "&cmd=" + jQuery(this).val();
                 parent.jQuery('#WidgetDowntime').parent().remove();
                 var popin = parent.jQuery('<div id="WidgetDowntime">');
 
-                popin.centreonPopin({
+                if (popin.centreonPopin({
                     open:true,
                     url:url
-                });
+                })) {
+                    $.each(checkValues.split(','), function(index, value) {
+                        localStorage.removeItem('w_hm_selection_' + value);
+                        $('#selection_' + value).prop('checked', false);
+                    });
+                }
 
            } else {
                alert("<?php echo _('Please select one or more items'); ?>");


### PR DESCRIPTION
fix MON-5882

in latest versions, if you perform an action on one or more host, the checkboxes remain ticked which is not practical to say the least. 

behavior before this patch : 

- add the host-monitoring widget in a custom view
- enable the more action and pagination option in the widget parameters
- tick one or more host's checkboxes
- perform an action like enable check in the more actions list 
- a popup will appear and disappear (meaning the action has been done), but the checkboxes are still ticked.



after the patch 
- add the host-monitoring widget in a custom view
- enable the more action and pagination option in the widget parameters
- tick one or more host's checkboxes
- perform an action like enable check in the more actions list 
- a popup will appear and disappear (meaning the action has been done), but the checkboxes are not ticket anymore.