### PR TITLE
fix(UI) use correct color codes (MON-14512)

### DIFF
--- a/host-monitoring/src/DB-Func.php
+++ b/host-monitoring/src/DB-Func.php
@@ -37,10 +37,10 @@
 function getColors($db)
 {
     $stateColors = array(
-        0 => "#88b917",
-        1 => "#e00b3d",
-        2 => "#82CFD8",
-        4 => "#2ad1d4"
+        0 => "#88B917",
+        1 => "#E00B3D",
+        2 => "#818285",
+        4 => "#2AD1D4"
     );
 
     // Get configured colors


### PR DESCRIPTION
Hi,

Some color `#codes` are wrong, let's then update them according to the Centreon-2 theme (`www/Themes/Centreon-2/style.css`).

See https://github.com/centreon/centreon-widget-global-health/pull/23 for other related PRs.

Pleaase backport at least up to 19.10.x.

Thank you 👍

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)