### PR TITLE
fix(secu): use jQuery 3.5.1 min file

### DIFF
--- a/host-monitoring/src/index.ihtml
+++ b/host-monitoring/src/index.ihtml
@@ -24,7 +24,7 @@
             var _num_edge_entries = 1;
             var _num_display_entries = 3;
         </script>
-        <script type="text/javascript" src="../../include/common/javascript/jquery/jquery.js"></script>
+        <script type="text/javascript" src="../../include/common/javascript/jquery/jquery.min.js"></script>
         <script type="text/javascript" src="../../include/common/javascript/jquery/plugins/pagination/jquery.pagination.js"></script>
         <script type="text/javascript" src="../../include/common/javascript/centreon/popin.js"></script>
         <script type="text/javascript" src="../../include/common/javascript/moment-with-locales.min.2.21.js"></script>


### PR DESCRIPTION
## Description

Replace the jQuery path to use Centreon's minified file

**Fixes** # (MON-6573)
Linked to https://github.com/centreon/centreon/pull/9481

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

