### PR TITLE
chore(build): fix build for 21.10

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,6 @@ Please include a short resume of the changes and what is the purpose of PR. Any 
 
 ## Target serie
 
-- [ ] 19.10.x
 - [ ] 20.04.x
 - [ ] 20.10.x
 - [ ] 21.04.x

--- a/host-monitoring/configs.xml
+++ b/host-monitoring/configs.xml
@@ -4,7 +4,7 @@
     <email>contact@centreon.com</email>
     <website>http://www.centreon.com</website>
     <description>This interactive host event console widget displays the hosts status and allows to act on them (acknowledge, add downtime, etc.). Multiple parameters allow to select which hosts to display (based on their name, hostgroup, status, etc.) or which columns (name, alias, IP address, status duration, output, etc.).</description>
-    <version>21.10.0-beta.1</version>
+    <version>21.10.0</version>
     <keywords>centreon, widget, host, monitoring</keywords>
     <screenshot></screenshot>
     <thumbnail>./widgets/host-monitoring/resources/centreon-logo.png</thumbnail>


### PR DESCRIPTION
Fixing build for the 21.10.

The version specified in the config.xml is used in the spectemplate of the widget. The spectemplate does not allow -beta.1 as version prefix